### PR TITLE
README.rst Update!

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,11 @@ See also https://github.com/audreyr/cookiecutter.
 Usage
 -----
 
+
+
 Generate a Python package project::
 
+    cd <horizon-dir>
     cookiecutter https://github.com/openstack/ui-cookiecutter.git
 
 This command prompts interactive input. Please check these parameters::
@@ -50,9 +53,10 @@ If you want to generate without interactive input, you can use example values fo
 Run with OpenStack Horizon::
 
     cd <repo_name>
-    pip install
+    pip install .
     cp <repo_name>/<module_name>/enabled/_90_project_<panel_group>_panelgroup.py <horizon-dir>/openstack_dashboard/local/enabled
     cp <repo_name>/<module_name>/enabled/_91_project_<panel_group>_<panel>s.py <horizon-dir>/openstack_dashboard/local/enabled
+    mv <module_name> ..
 
 then reboot the Horizon.
 

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,12 @@ See also https://github.com/audreyr/cookiecutter.
 Usage
 -----
 
+First, go to horizon directory::
 
+    cd <horizon-dir>
 
 Generate a Python package project::
 
-    cd <horizon-dir>
     cookiecutter https://github.com/openstack/ui-cookiecutter.git
 
 This command prompts interactive input. Please check these parameters::


### PR DESCRIPTION
1. First of installation guide mentioned redirect to Horizon root.

1. `pip install` update with `pip install .`

1. Mentioned move <module_name> directory to horizon directory root for excepting `MODUL_NOT_FOUND_ERROR(<module_name>)` error